### PR TITLE
minor fix to logging maf exclusions

### DIFF
--- a/munge_sumstats.py
+++ b/munge_sumstats.py
@@ -261,6 +261,7 @@ def parse_dat(dat_gen, convert_colname, merge_alleles, log, args):
             old = new
 
         if 'FRQ' in dat.columns:
+            old = ii.sum()
             ii &= filter_frq(dat['FRQ'], log, args)
             new = ii.sum()
             drops['FRQ'] += old - new


### PR DESCRIPTION
Fix for the minor logging issue in `munge_sumstats.py` noted in #43. Opening pull request since I haven't tested this yet.

Issue: `munge_sumstats.py` incorrectly reports the number of SNPs filtered out for MAF. Per the initial report, SNPs excluded based on `--merge-alleles` were being counted towards the number of SNPs excluded due to MAF.

Fix: Variable `old` tracking the number of SNPs before each filter wasn't getting updated after the `merge-alleles` filter unless there was a filter on info. Now forcing an update in the MAF filter.