### PR TITLE
fixed signed_sumstat datatype bug + 2 minor ldscore computation bugs

### DIFF
--- a/ldscore/ldscore.py
+++ b/ldscore/ldscore.py
@@ -166,7 +166,7 @@ class __GenotypeArrayInMemory__(object):
         m, n = self.m, self.n
         block_sizes = np.array(np.arange(m) - block_left)
         block_sizes = np.ceil(block_sizes / c)*c
-        if not np.any(annot):
+        if annot is None:
             annot = np.ones((m, 1))
         else:
             annot_m = annot.shape[0]
@@ -204,7 +204,7 @@ class __GenotypeArrayInMemory__(object):
             # this happens w/ sparse categories (i.e., pathways)
             # update the block
             old_b = b
-            b = block_sizes[l_B]
+            b = int(block_sizes[l_B])
             if l_B > b0 and b > 0:
                 # block_size can't increase more than c
                 # block_size can't be less than c unless it is zero

--- a/munge_sumstats.py
+++ b/munge_sumstats.py
@@ -634,8 +634,14 @@ def munge_sumstats(args, p=True):
             merge_alleles = None
 
         (openfunc, compression) = get_compression(args.sumstats)
-        dat_gen = pd.read_csv(args.sumstats, delim_whitespace=True, header=0, compression=compression,
-                              usecols=cname_translation.keys(), na_values=['.', 'NA'], iterator=True, chunksize=args.chunksize)
+
+        # figure out which columns are going to involve sign information, so we can ensure
+        # they're read as floats
+        signed_sumstat_cols = [k for k,v in cname_translation.items() if v=='SIGNED_SUMSTAT']
+        dat_gen = pd.read_csv(args.sumstats, delim_whitespace=True, header=0,
+                compression=compression, usecols=cname_translation.keys(),
+                na_values=['.', 'NA'], iterator=True, chunksize=args.chunksize,
+                dtype={c:np.float64 for c in signed_sumstat_cols})
 
         dat = parse_dat(dat_gen, cname_translation, merge_alleles, log, args)
         if len(dat) == 0:


### PR DESCRIPTION
- Fixed a bug in munge_sumstats wherein irregularities in the input file can lead to the data type of SIGNED_SUMSTAT being non-float, in which case the signs of the z-scores in the output end up wrong.

- Fixed a minor bug in ldsc.py in which a float is used as an index into an array, which gives a fatal error when used with some versions of pandas

- Fixed a bug in ldsc.py in which if an annotation consists of all 0's for an entire chromosome then the ldscores that are outputted are the total ld scores, as if no annotation had been supplied at all, rather than all 0's, which is the correct set of ld-scores to the annotation.