### PR TITLE
SSGAC changes

### DIFF
--- a/ldscore/allele_info.py
+++ b/ldscore/allele_info.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import
+import itertools as it
+import functools
+import logging
+
+'''
+This script contains useful objects related to allele information and relationships for ../munge_sumstats.py
+
+'''
+
+_N_CHR = 22
+# complementary bases
+COMPLEMENT = {'A': 'T', 'T': 'A', 'C': 'G', 'G': 'C'}
+# bases
+BASES = COMPLEMENT.keys()
+# true iff strand ambiguous
+STRAND_AMBIGUOUS = {''.join(x): x[0] == COMPLEMENT[x[1]]
+                    for x in it.product(BASES, BASES)
+                    if x[0] != x[1]}
+# SNPS we want to keep (pairs of alleles)
+VALID_SNPS = {x for x in map(lambda y: ''.join(y), it.product(BASES, BASES))
+              if x[0] != x[1] and not STRAND_AMBIGUOUS[x]}
+
+VALID_andSA_SNPS = {x for x in map(lambda y: ''.join(y), it.product(BASES, BASES))
+              if x[0] != x[1]}
+
+# T iff SNP 1 has the same alleles as SNP 2 (allowing for strand or ref allele flip).
+MATCH_ALLELES = {x for x in map(lambda y: ''.join(y), it.product(VALID_SNPS, VALID_SNPS))
+                 # strand and ref match
+                 if ((x[0] == x[2]) and (x[1] == x[3])) or
+                 # ref match, strand flip
+                 ((x[0] == COMPLEMENT[x[2]]) and (x[1] == COMPLEMENT[x[3]])) or
+                 # ref flip, strand match
+                 ((x[0] == x[3]) and (x[1] == x[2])) or
+                 ((x[0] == COMPLEMENT[x[3]]) and (x[1] == COMPLEMENT[x[2]]))}  # strand and ref flip
+# T iff SNP 1 has the same alleles as SNP 2 w/ ref allele flip.
+FLIP_ALLELES = {''.join(x):
+                ((x[0] == x[3]) and (x[1] == x[2])) or  # strand match
+                # strand flip
+                ((x[0] == COMPLEMENT[x[3]]) and (x[1] == COMPLEMENT[x[2]]))
+                for x in MATCH_ALLELES}
+
+
+__version__ = '1.1.0'
+MASTHEAD = "*********************************************************************\n"
+MASTHEAD += "* LD Score Regression (LDSC)\n"
+MASTHEAD += "* Version {V}\n".format(V=__version__)
+MASTHEAD += "* (C) 2014-2015 Brendan Bulik-Sullivan and Hilary Finucane\n"
+MASTHEAD += "* Broad Institute of MIT and Harvard / MIT Department of Mathematics\n"
+MASTHEAD += "* GNU General Public License v3\n"
+MASTHEAD += "*********************************************************************\n"
+
+
+
+def sec_to_str(t):
+    '''Convert seconds to days:hours:minutes:seconds'''
+    [d, h, m, s, n] = functools.reduce(lambda ll, b : divmod(ll[0], b) + ll[1:], [(t, 1), 60, 60, 24])
+    f = ''
+    if d > 0:
+        f += '{D}d:'.format(D=d)
+    if h > 0:
+        f += '{H}h:'.format(H=h)
+    if m > 0:
+        f += '{M}m:'.format(M=m)
+
+    f += '{S}s'.format(S=s)
+    return f
+

--- a/ldscore/irwls.py
+++ b/ldscore/irwls.py
@@ -5,9 +5,10 @@ Iterativey re-weighted least squares.
 
 '''
 from __future__ import division
+from __future__ import absolute_import
 import numpy as np
-import jackknife as jk
-
+import ldscore.jackknife as jk
+import logging
 
 class IRWLS(object):
 
@@ -109,10 +110,10 @@ class IRWLS(object):
                 'w has shape {S}. w must have shape ({N}, 1).'.format(S=w.shape, N=n))
 
         w = np.sqrt(w)
-        for i in xrange(2):  # update this later
+        for i in range(2):  # update this later
             new_w = np.sqrt(update_func(cls.wls(x, y, w)))
             if new_w.shape != w.shape:
-                print 'IRWLS update:', new_w.shape, w.shape
+                logging.info(('IRWLS update:', new_w.shape, w.shape))
                 raise ValueError('New weights must have same shape.')
             else:
                 w = new_w

--- a/ldscore/jackknife.py
+++ b/ldscore/jackknife.py
@@ -13,7 +13,9 @@ of the data.
 '''
 
 from __future__ import division
+from __future__ import absolute_import
 import numpy as np
+import logging
 from scipy.optimize import nnls
 np.seterr(divide='raise', invalid='raise')
 
@@ -256,7 +258,7 @@ class LstsqJackknifeSlow(Jackknife):
         '''
         _check_shape(x, y)
         d = [func(np.vstack([x[0:s[i], ...], x[s[i + 1]:, ...]]), np.vstack([y[0:s[i], ...], y[s[i + 1]:, ...]]))
-             for i in xrange(len(s) - 1)]
+             for i in range(len(s) - 1)]
 
         return np.concatenate(d, axis=0)
 
@@ -346,7 +348,7 @@ class LstsqJackknifeFast(Jackknife):
         n_blocks = len(s) - 1
         xtx_block_values = np.zeros((n_blocks, p, p))
         xty_block_values = np.zeros((n_blocks, p))
-        for i in xrange(n_blocks):
+        for i in range(n_blocks):
             xty_block_values[i, ...] = np.dot(
                 x[s[i]:s[i + 1], ...].T, y[s[i]:s[i + 1], ...]).reshape((1, p))
             xtx_block_values[i, ...] = np.dot(
@@ -417,7 +419,7 @@ class LstsqJackknifeFast(Jackknife):
         delete_values = np.zeros((n_blocks, p))
         xty_tot = np.sum(xty_block_values, axis=0)
         xtx_tot = np.sum(xtx_block_values, axis=0)
-        for j in xrange(n_blocks):
+        for j in range(n_blocks):
             delete_xty = xty_tot - xty_block_values[j]
             delete_xtx = xtx_tot - xtx_block_values[j]
             delete_values[j, ...] = np.linalg.solve(
@@ -507,7 +509,7 @@ class RatioJackknife(Jackknife):
         '''
         n_blocks, p = denom.shape
         pseudovalues = np.zeros((n_blocks, p))
-        for j in xrange(0, n_blocks):
+        for j in range(0, n_blocks):
             pseudovalues[j, ...] = n_blocks * est - \
                 (n_blocks - 1) * numer[j, ...] / denom[j, ...]
 

--- a/ldscore/ldscore.py
+++ b/ldscore/ldscore.py
@@ -1,7 +1,8 @@
 from __future__ import division
+from __future__ import absolute_import
 import numpy as np
 import bitarray as ba
-
+import logging
 
 def getBlockLefts(coords, max_dist):
     '''
@@ -24,7 +25,7 @@ def getBlockLefts(coords, max_dist):
     M = len(coords)
     j = 0
     block_left = np.zeros(M)
-    for i in xrange(M):
+    for i in range(M):
         while j < M and abs(coords[j] - coords[i]) > max_dist:
             j += 1
 
@@ -51,7 +52,7 @@ def block_left_to_right(block_left):
     M = len(block_left)
     j = 0
     block_right = np.zeros(M)
-    for i in xrange(M):
+    for i in range(M):
         while j < M and block_left[j] <= i:
             j += 1
 
@@ -85,7 +86,7 @@ class __GenotypeArrayInMemory__(object):
                 self.n)
 
             if self.n > 0:
-                print 'After filtering, {n} individuals remain'.format(n=self.n)
+                logging.info('After filtering, {n} individuals remain'.format(n=self.n))
             else:
                 raise ValueError('After filtering, no individuals remain')
 
@@ -99,7 +100,7 @@ class __GenotypeArrayInMemory__(object):
             self.geno, self.m, self.n, self.mafMin, keep_snps)
 
         if self.m > 0:
-            print 'After filtering, {m} SNPs remain'.format(m=self.m)
+            logging.info('After filtering, {m} SNPs remain'.format(m=self.m))
         else:
             raise ValueError('After filtering, no SNPs remain')
 
@@ -190,7 +191,7 @@ class __GenotypeArrayInMemory__(object):
         rfuncAB = np.zeros((b, c))
         rfuncBB = np.zeros((c, c))
         # chunk inside of block
-        for l_B in xrange(0, b, c):  # l_B := index of leftmost SNP in matrix B
+        for l_B in range(0, b, c):  # l_B := index of leftmost SNP in matrix B
             B = A[:, l_B:l_B+c]
             np.dot(A.T, B / n, out=rfuncAB)
             rfuncAB = func(rfuncAB)
@@ -199,7 +200,7 @@ class __GenotypeArrayInMemory__(object):
         b0 = b
         md = int(c*np.floor(m/c))
         end = md + 1 if md != m else md
-        for l_B in xrange(b0, end, c):
+        for l_B in range(b0, end, c):
             # check if the annot matrix is all zeros for this block + chunk
             # this happens w/ sparse categories (i.e., pathways)
             # update the block
@@ -334,7 +335,7 @@ class PlinkBEDFile(__GenotypeArrayInMemory__):
         m_poly = 0
         y = ba.bitarray()
         if keep_snps is None:
-            keep_snps = xrange(m)
+            keep_snps = range(m)
         kept_snps = []
         freq = []
         for e, j in enumerate(keep_snps):
@@ -396,7 +397,7 @@ class PlinkBEDFile(__GenotypeArrayInMemory__):
         X = np.array(slice.decode(self._bedcode), dtype="float64").reshape((b, nru)).T
         X = X[0:n, :]
         Y = np.zeros(X.shape)
-        for j in xrange(0, b):
+        for j in range(0, b):
             newsnp = X[:, j]
             ii = newsnp != 9
             avg = np.mean(newsnp[ii])

--- a/ldscore/parse.py
+++ b/ldscore/parse.py
@@ -6,10 +6,11 @@ This module contains functions for parsing various ldsc-defined file formats.
 '''
 
 from __future__ import division
+from __future__ import absolute_import
 import numpy as np
 import pandas as pd
 import os
-
+import logging
 
 def series_eq(x, y):
     '''Compare series, return False if lengths not equal.'''
@@ -135,7 +136,7 @@ def ldscore(fh, num=None):
     if num is not None:  # num files, e.g., one per chromosome
         first_fh = sub_chr(fh, 1) + suffix
         s, compression = which_compression(first_fh)
-        chr_ld = [l2_parser(sub_chr(fh, i) + suffix + s, compression) for i in xrange(1, num + 1)]
+        chr_ld = [l2_parser(sub_chr(fh, i) + suffix + s, compression) for i in range(1, num + 1)]
         x = pd.concat(chr_ld)  # automatically sorted by chromosome
     else:  # just one file
         s, compression = which_compression(fh + suffix)
@@ -154,7 +155,7 @@ def M(fh, num=None, N=2, common=False):
         suffix += '_5_50'
 
     if num is not None:
-        x = np.sum([parsefunc(sub_chr(fh, i) + suffix) for i in xrange(1, num + 1)], axis=0)
+        x = np.sum([parsefunc(sub_chr(fh, i) + suffix) for i in range(1, num + 1)], axis=0)
     else:
         x = parsefunc(fh + suffix)
 
@@ -190,7 +191,7 @@ def annot(fh_list, num=None, frqfile=None):
 
         y = []
         M_tot = 0
-        for chr in xrange(1, num + 1):
+        for chr in range(1, num + 1):
             if frqfile is not None:
                 df_annot_chr_list = [annot_parser(sub_chr(fh, chr) + annot_suffix[i], annot_compression[i],
                                                   sub_chr(frqfile, chr) + frq_suffix, frq_compression)

--- a/ldscore/regressions.py
+++ b/ldscore/regressions.py
@@ -8,11 +8,13 @@ Last column = intercept.
 
 '''
 from __future__ import division
+from __future__ import absolute_import
 import numpy as np
 import pandas as pd
+import logging
 from scipy.stats import norm, chi2
-import jackknife as jk
-from irwls import IRWLS
+import ldscore.jackknife as jk
+from ldscore.irwls import IRWLS
 from scipy.stats import t as tdist
 from collections import namedtuple
 np.seterr(divide='raise', invalid='raise')
@@ -455,7 +457,7 @@ class Hsq(LD_Score_Regression):
         if self.n_annot > 1:
             if ref_ld_colnames is None:
                 ref_ld_colnames = ['CAT_' + str(i)
-                                   for i in xrange(self.n_annot)]
+                                   for i in range(self.n_annot)]
 
             out.append('Categories: ' + ' '.join(ref_ld_colnames))
 

--- a/ldscore/sumstats.py
+++ b/ldscore/sumstats.py
@@ -7,14 +7,16 @@ regression is implemented in the regressions module.
 
 '''
 from __future__ import division
+from __future__ import absolute_import
 import numpy as np
 import pandas as pd
 from scipy import stats
 import itertools as it
-import parse as ps
-import regressions as reg
+import ldscore.parse as ps
+import ldscore.regressions as reg
 import sys
 import traceback
+import logging
 import copy
 import os
 
@@ -54,14 +56,14 @@ def _splitp(fstr):
     return flist
 
 
-def _select_and_log(x, ii, log, msg):
+def _select_and_log(x, ii, msg):
     '''Fiter down to rows that are True in ii. Log # of SNPs removed.'''
     new_len = ii.sum()
     if new_len == 0:
         raise ValueError(msg.format(N=0))
     else:
         x = x[ii]
-        log.log(msg.format(N=new_len))
+        logging.info(msg.format(N=new_len))
     return x
 
 
@@ -76,32 +78,32 @@ def smart_merge(x, y):
     return out
 
 
-def _read_ref_ld(args, log):
+def _read_ref_ld(args):
     '''Read reference LD Scores.'''
-    ref_ld = _read_chr_split_files(args.ref_ld_chr, args.ref_ld, log,
+    ref_ld = _read_chr_split_files(args.ref_ld_chr, args.ref_ld,
                                    'reference panel LD Score', ps.ldscore_fromlist)
-    log.log(
+    logging.info(
         'Read reference panel LD Scores for {N} SNPs.'.format(N=len(ref_ld)))
     return ref_ld
 
 
-def _read_annot(args, log):
+def _read_annot(args):
     '''Read annot matrix.'''
     try:
         if args.ref_ld is not None:
-            overlap_matrix, M_tot = _read_chr_split_files(args.ref_ld_chr, args.ref_ld, log,
+            overlap_matrix, M_tot = _read_chr_split_files(args.ref_ld_chr, args.ref_ld,
                                                           'annot matrix', ps.annot, frqfile=args.frqfile)
         elif args.ref_ld_chr is not None:
-            overlap_matrix, M_tot = _read_chr_split_files(args.ref_ld_chr, args.ref_ld, log,
+            overlap_matrix, M_tot = _read_chr_split_files(args.ref_ld_chr, args.ref_ld,
                                                       'annot matrix', ps.annot, frqfile=args.frqfile_chr)
     except Exception:
-        log.log('Error parsing .annot file.')
+        logging.info('Error parsing .annot file.')
         raise
 
     return overlap_matrix, M_tot
 
 
-def _read_M(args, log, n_annot):
+def _read_M(args, n_annot):
     '''Read M (--M, --M-file, etc).'''
     if args.M:
         try:
@@ -125,54 +127,54 @@ def _read_M(args, log, n_annot):
     return M_annot
 
 
-def _read_w_ld(args, log):
+def _read_w_ld(args):
     '''Read regression SNP LD.'''
     if (args.w_ld and ',' in args.w_ld) or (args.w_ld_chr and ',' in args.w_ld_chr):
         raise ValueError(
             '--w-ld must point to a single fileset (no commas allowed).')
-    w_ld = _read_chr_split_files(args.w_ld_chr, args.w_ld, log,
+    w_ld = _read_chr_split_files(args.w_ld_chr, args.w_ld,
                                  'regression weight LD Score', ps.ldscore_fromlist)
     if len(w_ld.columns) != 2:
         raise ValueError('--w-ld may only have one LD Score column.')
     w_ld.columns = ['SNP', 'LD_weights']  # prevent colname conflicts w/ ref ld
-    log.log(
+    logging.info(
         'Read regression weight LD Scores for {N} SNPs.'.format(N=len(w_ld)))
     return w_ld
 
 
-def _read_chr_split_files(chr_arg, not_chr_arg, log, noun, parsefunc, **kwargs):
+def _read_chr_split_files(chr_arg, not_chr_arg, noun, parsefunc, **kwargs):
     '''Read files split across 22 chromosomes (annot, ref_ld, w_ld).'''
     try:
         if not_chr_arg:
-            log.log('Reading {N} from {F} ...'.format(F=not_chr_arg, N=noun))
+            logging.info('Reading {N} from {F} ...'.format(F=not_chr_arg, N=noun))
             out = parsefunc(_splitp(not_chr_arg), **kwargs)
         elif chr_arg:
             f = ps.sub_chr(chr_arg, '[1-22]')
-            log.log('Reading {N} from {F} ...'.format(F=f, N=noun))
+            logging.info('Reading {N} from {F} ...'.format(F=f, N=noun))
             out = parsefunc(_splitp(chr_arg), _N_CHR, **kwargs)
     except ValueError as e:
-        log.log('Error parsing {N}.'.format(N=noun))
+        logging.info('Error parsing {N}.'.format(N=noun))
         raise e
 
     return out
 
 
-def _read_sumstats(args, log, fh, alleles=False, dropna=False):
+def _read_sumstats(args, fh, alleles=False, dropna=False):
     '''Parse summary statistics.'''
-    log.log('Reading summary statistics from {S} ...'.format(S=fh))
+    logging.info('Reading summary statistics from {S} ...'.format(S=fh))
     sumstats = ps.sumstats(fh, alleles=alleles, dropna=dropna)
     log_msg = 'Read summary statistics for {N} SNPs.'
-    log.log(log_msg.format(N=len(sumstats)))
+    logging.info(log_msg.format(N=len(sumstats)))
     m = len(sumstats)
     sumstats = sumstats.drop_duplicates(subset='SNP')
     if m > len(sumstats):
-        log.log(
+        logging.info(
             'Dropped {M} SNPs with duplicated rs numbers.'.format(M=m - len(sumstats)))
 
     return sumstats
 
 
-def _check_ld_condnum(args, log, ref_ld):
+def _check_ld_condnum(args, ref_ld):
     '''Check condition number of LD Score matrix.'''
     if len(ref_ld.shape) >= 2:
         cond_num = int(np.linalg.cond(ref_ld))
@@ -180,78 +182,99 @@ def _check_ld_condnum(args, log, ref_ld):
             if args.invert_anyway:
                 warn = "WARNING: LD Score matrix condition number is {C}. "
                 warn += "Inverting anyway because the --invert-anyway flag is set."
-                log.log(warn.format(C=cond_num))
+                logging.info(warn.format(C=cond_num))
             else:
                 warn = "WARNING: LD Score matrix condition number is {C}. "
                 warn += "Remove collinear LD Scores. "
                 raise ValueError(warn.format(C=cond_num))
 
 
-def _check_variance(log, M_annot, ref_ld):
+def _check_variance(M_annot, ref_ld):
     '''Remove zero-variance LD Scores.'''
-    ii = ref_ld.ix[:, 1:].var() == 0  # NB there is a SNP column here
+    ii = ref_ld.iloc[:, 1:].var() == 0  # NB there is a SNP column here
     if ii.all():
         raise ValueError('All LD Scores have zero variance.')
     else:
-        log.log('Removing partitioned LD Scores with zero variance.')
+        logging.info('Removing partitioned LD Scores with zero variance.')
         ii_snp = np.array([True] + list(~ii))
         ii_m = np.array(~ii)
-        ref_ld = ref_ld.ix[:, ii_snp]
+        ref_ld = ref_ld.iloc[:, ii_snp]
         M_annot = M_annot[:, ii_m]
 
     return M_annot, ref_ld, ii
 
 
-def _warn_length(log, sumstats):
+def _warn_length(sumstats):
     if len(sumstats) < 200000:
-        log.log(
+        logging.info(
             'WARNING: number of SNPs less than 200k; this is almost always bad.')
 
 
-def _print_cov(ldscore_reg, ofh, log):
+def _print_cov(ldscore_reg, ofh):
     '''Prints covariance matrix of slopes.'''
-    log.log(
+    logging.info(
         'Printing covariance matrix of the estimates to {F}.'.format(F=ofh))
     np.savetxt(ofh, ldscore_reg.coef_cov)
 
 
-def _print_delete_values(ldscore_reg, ofh, log):
+def _print_delete_values(ldscore_reg, ofh):
     '''Prints block jackknife delete-k values'''
-    log.log('Printing block jackknife delete values to {F}.'.format(F=ofh))
+    logging.info('Printing block jackknife delete values to {F}.'.format(F=ofh))
     np.savetxt(ofh, ldscore_reg.tot_delete_values)
 
-def _print_part_delete_values(ldscore_reg, ofh, log):
+def _print_part_delete_values(ldscore_reg, ofh):
     '''Prints partitioned block jackknife delete-k values'''
-    log.log('Printing partitioned block jackknife delete values to {F}.'.format(F=ofh))
+    logging.info('Printing partitioned block jackknife delete values to {F}.'.format(F=ofh))
     np.savetxt(ofh, ldscore_reg.part_delete_values)
 
 
-def _merge_and_log(ld, sumstats, noun, log):
+def _merge_and_log(ld, sumstats, noun):
     '''Wrap smart merge with log messages about # of SNPs.'''
     sumstats = smart_merge(ld, sumstats)
     msg = 'After merging with {F}, {N} SNPs remain.'
     if len(sumstats) == 0:
         raise ValueError(msg.format(N=len(sumstats), F=noun))
     else:
-        log.log(msg.format(N=len(sumstats), F=noun))
+        logging.info(msg.format(N=len(sumstats), F=noun))
 
     return sumstats
 
+def _read_ref(args):
 
-def _read_ld_sumstats(args, log, fh, alleles=False, dropna=True):
-    sumstats = _read_sumstats(args, log, fh, alleles=alleles, dropna=dropna)
-    ref_ld = _read_ref_ld(args, log)
+    ref_ld = _read_ref_ld(args)
     n_annot = len(ref_ld.columns) - 1
-    M_annot = _read_M(args, log, n_annot)
-    M_annot, ref_ld, novar_cols = _check_variance(log, M_annot, ref_ld)
-    w_ld = _read_w_ld(args, log)
-    sumstats = _merge_and_log(ref_ld, sumstats, 'reference panel LD', log)
-    sumstats = _merge_and_log(sumstats, w_ld, 'regression SNP LD', log)
-    w_ld_cname = sumstats.columns[-1]
+    M_annot = _read_M(args, n_annot)
+    M_annot, ref_ld, novar_cols = _check_variance(M_annot, ref_ld)
+    w_ld = _read_w_ld(args)
     ref_ld_cnames = ref_ld.columns[1:len(ref_ld.columns)]
-    return M_annot, w_ld_cname, ref_ld_cnames, sumstats, novar_cols
 
-def cell_type_specific(args, log):
+    return ref_ld, w_ld, M_annot, ref_ld_cnames, novar_cols
+
+def _read_ld_sumstats(args, fh, ref_ld, w_ld, alleles=False, dropna=True):
+    if type(fh) == pd.DataFrame:
+        sumstats=fh.dropna(how='any')
+        msg = '{N} variants are dropped due to N/A values.'
+        logging.info(msg.format(N=len(fh)-len(sumstats)))
+    else:
+        sumstats = _read_sumstats(args, fh, alleles=alleles, dropna=dropna)
+
+    sumstats = _merge_and_log(ref_ld, sumstats, 'reference panel LD')
+    sumstats = _merge_and_log(sumstats, w_ld, 'regression SNP LD')
+    w_ld_cname = sumstats.columns[-1]
+
+    if args.exclude: #--exclude
+        df_exclude = pd.read_csv(args.exclude, index_col=None, header=None)
+        df_exclude.columns = ['SNP']
+        sumstats = sumstats[~sumstats.SNP.isin(df_exclude.SNP)]
+        msg = 'After excluding variants from {F}, {N} SNPs remain.'
+        if len(sumstats) == 0:
+            raise ValueError(msg.format(N=len(sumstats), F='--exclude SNP list'))
+        else:
+            logging.info(msg.format(N=len(sumstats), F='--exclude SNP list'))
+
+    return sumstats, w_ld_cname
+
+def cell_type_specific(args):
     '''Cell type specific analysis'''
     args = copy.deepcopy(args)
     if args.intercept_h2 is not None:
@@ -259,11 +282,11 @@ def cell_type_specific(args, log):
     if args.no_intercept:
         args.intercept_h2 = 1
 
-    M_annot_all_regr, w_ld_cname, ref_ld_cnames_all_regr, sumstats, novar_cols = \
-            _read_ld_sumstats(args, log, args.h2_cts)
+    ref_ld, w_ld, M_annot_all_regr, ref_ld_cnames,novar_cols = _read_ref(args)
+    sumstats, w_ld_cname = _read_ld_sumstats(args, args.h2_cts, ref_ld, w_ld, alleles=True, dropna=True)
     M_tot = np.sum(M_annot_all_regr)
-    _check_ld_condnum(args, log, ref_ld_cnames_all_regr)
-    _warn_length(log, sumstats)
+    _check_ld_condnum(args, ref_ld_cnames_all_regr)
+    _warn_length(sumstats)
     n_snp = len(sumstats)
     n_blocks = min(n_snp, args.n_blocks)
     if args.chisq_max is None:
@@ -272,8 +295,8 @@ def cell_type_specific(args, log):
         chisq_max = args.chisq_max
 
     ii = np.ravel(sumstats.Z**2 < chisq_max)
-    sumstats = sumstats.ix[ii, :]
-    log.log('Removed {M} SNPs with chi^2 > {C} ({N} SNPs remain)'.format(
+    sumstats = sumstats.loc[ii, :]
+    logging.info('Removed {M} SNPs with chi^2 > {C} ({N} SNPs remain)'.format(
             C=chisq_max, N=np.sum(ii), M=n_snp-np.sum(ii)))
     n_snp = np.sum(ii)  # lambdas are late-binding, so this works
     ref_ld_all_regr = np.array(sumstats[ref_ld_cnames_all_regr]).reshape((len(sumstats),-1))
@@ -284,10 +307,10 @@ def cell_type_specific(args, log):
     results_columns = ['Name', 'Coefficient', 'Coefficient_std_error', 'Coefficient_P_value']
     results_data = []
     for (name, ct_ld_chr) in [x.split() for x in open(args.ref_ld_chr_cts).readlines()]:
-        ref_ld_cts_allsnps = _read_chr_split_files(ct_ld_chr, None, log,
+        ref_ld_cts_allsnps = _read_chr_split_files(ct_ld_chr, None,
                                    'cts reference panel LD Score', ps.ldscore_fromlist)
-        log.log('Performing regression.')
-        ref_ld_cts = np.array(pd.merge(keep_snps, ref_ld_cts_allsnps, on='SNP', how='left').ix[:,1:])
+        logging.info('Performing regression.')
+        ref_ld_cts = np.array(pd.merge(keep_snps, ref_ld_cts_allsnps, on='SNP', how='left').loc[:,1:])
         if np.any(np.isnan(ref_ld_cts)):
             raise ValueError ('Missing some LD scores from cts files. Are you sure all SNPs in ref-ld-chr are also in ref-ld-chr-cts')
 
@@ -309,12 +332,12 @@ def cell_type_specific(args, log):
     df_results = pd.DataFrame(data = results_data, columns = results_columns)
     df_results.sort_values(by = 'Coefficient_P_value', inplace=True)
     df_results.to_csv(args.out+'.cell_type_results.txt', sep='\t', index=False)
-    log.log('Results printed to '+args.out+'.cell_type_results.txt')
+    logging.info('Results printed to '+args.out+'.cell_type_results.txt')
 
 
-def estimate_h2(args, log):
+def estimate_h2(args):
     '''Estimate h2 and partitioned h2.'''
-    args = copy.deepcopy(args)
+    #args = copy.deepcopy(args)
     if args.samp_prev is not None and args.pop_prev is not None:
         args.samp_prev, args.pop_prev = map(
             float, [args.samp_prev, args.pop_prev])
@@ -322,65 +345,123 @@ def estimate_h2(args, log):
         args.intercept_h2 = float(args.intercept_h2)
     if args.no_intercept:
         args.intercept_h2 = 1
-    M_annot, w_ld_cname, ref_ld_cnames, sumstats, novar_cols = _read_ld_sumstats(
-        args, log, args.h2)
-    ref_ld = np.array(sumstats[ref_ld_cnames])
-    _check_ld_condnum(args, log, ref_ld_cnames)
-    _warn_length(log, sumstats)
-    n_snp = len(sumstats)
-    n_blocks = min(n_snp, args.n_blocks)
-    n_annot = len(ref_ld_cnames)
-    chisq_max = args.chisq_max
-    old_weights = False
-    if n_annot == 1:
-        if args.two_step is None and args.intercept_h2 is None:
-            args.two_step = 30
-    else:
-        old_weights = True
-        if args.chisq_max is None:
-            chisq_max = max(0.001*sumstats.N.max(), 80)
+    ref_ld_orig, w_ld_orig, M_annot_orig, ref_ld_cnames_orig, novar_cols_orig = _read_ref(args)
 
-    s = lambda x: np.array(x).reshape((n_snp, 1))
-    chisq = s(sumstats.Z**2)
-    if chisq_max is not None:
-        ii = np.ravel(chisq < chisq_max)
-        sumstats = sumstats.ix[ii, :]
-        log.log('Removed {M} SNPs with chi^2 > {C} ({N} SNPs remain)'.format(
-                C=chisq_max, N=np.sum(ii), M=n_snp-np.sum(ii)))
-        n_snp = np.sum(ii)  # lambdas are late-binding, so this works
-        ref_ld = np.array(sumstats[ref_ld_cnames])
-        chisq = chisq[ii].reshape((n_snp, 1))
+    H2 = []
+    sumstats_list = {}
+
+    if type(args.h2) == str: # command line case
+        h2_paths, h2_files = _parse_(args.h2) # rows
+        h2_list = h2_paths # columns
+        n_pheno = len(h2_paths)
+    else: # python case
+        h2_frames = args.h2 # rows
+        h2_list = list(h2_frames) # columns
+        n_pheno = len(args.h2)
+        h2_files =  []
+        for i in range(n_pheno):
+            h2_files.append("Trait_{}".format(i+1))
 
     if args.two_step is not None:
-        log.log('Using two-step estimator with cutoff at {M}.'.format(M=args.two_step))
+        logging.info('Using two-step estimator with cutoff at {M}.'.format(M=args.two_step))
 
-    hsqhat = reg.Hsq(chisq, ref_ld, s(sumstats[w_ld_cname]), s(sumstats.N),
-                     M_annot, n_blocks=n_blocks, intercept=args.intercept_h2,
-                     twostep=args.two_step, old_weights=old_weights)
+    for k, p1_orig in enumerate(h2_list):
+
+        ref_ld, w_ld, M_annot, ref_ld_cnames, novar_cols=map(lambda x: x.copy(),(ref_ld_orig, w_ld_orig, M_annot_orig, ref_ld_cnames_orig, novar_cols_orig))
+
+        if type(args.h2) == str:
+            p1 = p1_orig
+        else:
+            p1 = p1_orig.copy()
+
+        sumstats, w_ld_cname = _read_ld_sumstats(args, p1, ref_ld, w_ld, alleles=True, dropna=True)
+        sumstats_list[k] = pd.DataFrame(sumstats)
+        ref_ld = np.array(sumstats[ref_ld_cnames])
+        _check_ld_condnum(args, ref_ld_cnames)
+        _warn_length(sumstats)
+        n_snp = len(sumstats)
+        n_blocks = min(n_snp, args.n_blocks)
+
+        n_annot = len(ref_ld_cnames)
+        chisq_max = args.chisq_max
+        old_weights = False
+        if n_annot == 1:
+            if args.two_step is None and args.intercept_h2 is None:
+                args.two_step = float('inf')
+        else:
+            old_weights = True
+            if args.chisq_max is None:
+                chisq_max = max(0.001*sumstats.N.max(), 80)
+
+        s = lambda x: np.array(x).reshape((n_snp, 1))
+        chisq = s(sumstats.Z**2)
+        if chisq_max is not None:
+            ii = np.ravel(chisq < chisq_max)
+            sumstats = sumstats.loc[ii, :]
+            logging.info('Removed {M} SNPs with chi^2 > {C} ({N} SNPs remain)'.format(
+                    C=chisq_max, N=np.sum(ii), M=n_snp-np.sum(ii)))
+            n_snp = np.sum(ii)  # lambdas are late-binding, so this works
+            ref_ld = np.array(sumstats[ref_ld_cnames])
+            chisq = chisq[ii].reshape((n_snp, 1))
+
+        hsqhat = reg.Hsq(chisq, ref_ld, s(sumstats[w_ld_cname]), s(sumstats.N),
+                         M_annot, n_blocks=n_blocks, intercept=args.intercept_h2,
+                         twostep=args.two_step, old_weights=old_weights)
+
+        H2.append(hsqhat)
+        _print_h2(args, hsqhat, ref_ld_cnames, k, n_pheno)
+
+        if args.overlap_annot:
+            overlap_matrix, M_tot = _read_annot(args)
+
+            df_results = hsqhat._overlap_output(ref_ld_cnames, overlap_matrix, M_annot, M_tot, args.print_coefficients)
+            df_results.to_csv(args.out+'.results', sep="\t", index=False)
+            logging.info('Results printed to '+args.out+'.results')
+
+    tables = write_h2_table(args, H2, h2_files, sumstats_list)
+
+    if args.print_estimates:
+        logging.info('\n Writting h2 estimate tables to text files...')
+        tables['h2'].to_csv(args.out + '_h2_estimates.txt', sep='\t', index=False)
 
     if args.print_cov:
-        _print_cov(hsqhat, args.out + '.cov', log)
+        logging.info('Printing estimation covariance results to files...')
+        tables = print_cov(args, tables, H2=H2, h2_files=h2_files)
+
     if args.print_delete_vals:
-        _print_delete_values(hsqhat, args.out + '.delete', log)
-        _print_part_delete_values(hsqhat, args.out + '.part_delete', log)
+        logging.info('Printing jacknife delete values to files...')
+        tables = print_delete_vals(args, tables, H2=H2, h2_files=h2_files)
 
-    log.log(hsqhat.summary(ref_ld_cnames, P=args.samp_prev, K=args.pop_prev, overlap = args.overlap_annot))
-    if args.overlap_annot:
-        overlap_matrix, M_tot = _read_annot(args, log)
+    if args.write_excel:
+        logging.info('Writing estimates to excel tables...')
+        writer = pd.ExcelWriter(args.out + '_tables.xlsx')
+        for tab_name,tab in tables.items():
+            tab.to_excel(writer, tab_name)
+        writer.save()
 
-        # overlap_matrix = overlap_matrix[np.array(~novar_cols), np.array(~novar_cols)]#np.logical_not
-        df_results = hsqhat._overlap_output(ref_ld_cnames, overlap_matrix, M_annot, M_tot, args.print_coefficients)
-        df_results.to_csv(args.out+'.results', sep="\t", index=False)
-        log.log('Results printed to '+args.out+'.results')
+    return H2, tables
 
-    return hsqhat
+def estimate_rg(args):
 
+    '''Estimate rg between all pairs of traits.
+              
+    '''
+    #args = copy.deepcopy(args)
+    RG = []
+    sumstats_list = {}
 
-def estimate_rg(args, log):
-    '''Estimate rg between trait 1 and a list of other traits.'''
-    args = copy.deepcopy(args)
-    rg_paths, rg_files = _parse_rg(args.rg)
-    n_pheno = len(rg_paths)
+    if type(args.rg) == str: # command line case
+        rg_paths, rg_files = _parse_(args.rg) # rows
+        rg_list = rg_paths # columns
+        n_pheno = len(rg_paths)
+    else: # python case
+        rg_frames = args.rg # rows
+        rg_list = list(rg_frames) # columns
+        n_pheno = len(args.rg)
+        rg_files =  []
+        for i in range(n_pheno):
+            rg_files.append("Trait_{}".format(i+1))       
+
     f = lambda x: _split_or_none(x, n_pheno)
     args.intercept_h2, args.intercept_gencov, args.samp_prev, args.pop_prev = map(f,
         (args.intercept_h2, args.intercept_gencov, args.samp_prev, args.pop_prev))
@@ -389,68 +470,230 @@ def estimate_rg(args, log):
                                                (args.samp_prev, '--samp-prev'),
                                                (args.pop_prev, '--pop-prev')))
     if args.no_intercept:
-        args.intercept_h2 = [1 for _ in xrange(n_pheno)]
-        args.intercept_gencov = [0 for _ in xrange(n_pheno)]
-    p1 = rg_paths[0]
-    out_prefix = args.out + rg_files[0]
-    M_annot, w_ld_cname, ref_ld_cnames, sumstats, _ = _read_ld_sumstats(args, log, p1,
-                                                                        alleles=True, dropna=True)
-    RG = []
-    n_annot = M_annot.shape[1]
-    if n_annot == 1 and args.two_step is None and args.intercept_h2 is None:
-        args.two_step = 30
-    if args.two_step is not None:
-        log.log('Using two-step estimator with cutoff at {M}.'.format(M=args.two_step))
+        args.intercept_h2 = [1 for _ in range(n_pheno)]
+        args.intercept_gencov = [0 for _ in range(n_pheno)]
 
-    for i, p2 in enumerate(rg_paths[1:n_pheno]):
-        log.log(
-            'Computing rg for phenotype {I}/{N}'.format(I=i + 2, N=len(rg_paths)))
-        try:
-            loop = _read_other_sumstats(args, log, p2, sumstats, ref_ld_cnames)
-            rghat = _rg(loop, args, log, M_annot, ref_ld_cnames, w_ld_cname, i)
+    ref_ld, w_ld, M_annot, ref_ld_cnames, novar_cols = _read_ref(args)
+        
+    for k, p1_orig in enumerate(rg_list): # rows
+
+        if type(args.rg) == str:
+            p1 = p1_orig 
+        else:
+            p1 = p1_orig.copy()
+
+        sumstats, w_ld_cname = _read_ld_sumstats(args, p1, ref_ld, w_ld, alleles=True, dropna=True)
+        n_annot = M_annot.shape[1]
+        sumstats_list[k] = pd.DataFrame(sumstats)
+        out_prefix = args.out + rg_files[k]
+
+        if n_annot == 1 and args.two_step is None and args.intercept_h2 is None:
+            args.two_step = float('inf')
+        if args.two_step is not None:
+            logging.info('Using two-step estimator with cutoff at {M}.'.format(M=args.two_step))
+
+        for i in range(k, n_pheno): # columns
+            p2 = rg_list[i] if type(args.rg) == str else rg_list[i].copy()
+            loop = _read_other_sumstats(args, p2, sumstats, ref_ld_cnames, i, k)
+            rghat = _rg(loop, args, M_annot, ref_ld_cnames, w_ld_cname, k, i)
             RG.append(rghat)
-            _print_gencor(args, log, rghat, ref_ld_cnames, i, rg_paths, i == 0)
-            out_prefix_loop = out_prefix + '_' + rg_files[i + 1]
-            if args.print_cov:
-                _print_rg_cov(rghat, out_prefix_loop, log)
-            if args.print_delete_vals:
-                _print_rg_delete_values(rghat, out_prefix_loop, log)
 
-        except Exception:  # keep going if phenotype 50/100 causes an error
-            msg = 'ERROR computing rg for phenotype {I}/{N}, from file {F}.'
-            log.log(msg.format(I=i + 2, N=len(rg_paths), F=rg_paths[i + 1]))
-            ex_type, ex, tb = sys.exc_info()
-            log.log(traceback.format_exc(ex) + '\n')
-            if len(RG) <= i:  # if exception raised before appending to RG
-                RG.append(None)
+            if i > k:
+                logging.info('Computing rg for phenotypes {K}/{N}-{I}/{N}'.format(K=k+1, I=i+1, N=len(rg_list)))
+                _print_gencor(args, rghat, ref_ld_cnames, k,i, rg_list, True)
 
-    log.log('\nSummary of Genetic Correlation Results\n' +
-            _get_rg_table(rg_paths, RG, args))
-    return RG
+    X = np.empty(shape=[n_pheno,n_pheno], dtype=object)
+    X.fill(np.nan)
+    X[np.triu_indices(n_pheno)] = RG
+    X[(np.triu_indices(n_pheno)[1],np.triu_indices(n_pheno)[0])] = RG
+    RG = X
 
+    tables = write_rg_table(args, RG, n_pheno, rg_files, sumstats_list)
 
-def _read_other_sumstats(args, log, p2, sumstats, ref_ld_cnames):
-    loop = _read_sumstats(args, log, p2, alleles=True, dropna=False)
-    loop = _merge_sumstats_sumstats(args, sumstats, loop, log)
-    loop = loop.dropna(how='any')
+    if args.print_estimates:
+        logging.info('\n Writting rg estimate tables to text files...')
+        for tab_name,tab in tables.items():
+            tab.to_csv(args.out + '_{}'.format(tab_name) + '_estimates.txt', sep='\t', index=False)
+
+    if args.print_cov:
+        logging.info('Printing estimation covariance results to files...')
+        tables = print_cov(args, tables, RG=RG, rg_files=rg_files)
+
+    if args.print_delete_vals:
+        logging.info('Printing jacknife delete values to files...')
+        tables = print_delete_vals(args, tables, RG=RG, rg_files=rg_files)        
+
+    if args.write_excel:
+        logging.info('Writing estimates to excel tables...')
+        writer = pd.ExcelWriter(args.out + '_tables.xlsx')
+        for tab_name,tab in tables.items():
+            tab.to_excel(writer, tab_name)
+        writer.save()
+
+    return RG, tables
+
+def write_h2_table(args, H2, h2_files, sumstats_list):
+    logging.info('Formatting heritability estimates ...')
+    pd.options.display.float_format = '{:.3f}'.format
+    tables = dict()
+    tables['h2'] = pd.DataFrame(index=h2_files)
+
+    for i, phen in enumerate(h2_files):
+        hsqhat = H2[i]
+        tables['h2'].loc[phen, 'SNPs (M)'] = len(sumstats_list[i])   
+        tables['h2'].loc[phen, 'h2'] =  hsqhat.tot
+        tables['h2'].loc[phen, 'h2_se'] = hsqhat.tot_se
+        tables['h2'].loc[phen, 'lambda GC'] = hsqhat.lambda_gc
+        tables['h2'].loc[phen, 'Mean chi2'] = hsqhat.mean_chisq
+        tables['h2'].loc[phen, 'Intercept'] = hsqhat.intercept
+        tables['h2'].loc[phen, 'Intercept_se'] = hsqhat.intercept_se
+        if not args.no_intercept and (args.intercept_h2 is None) and (args.intercept_gencov is None):
+            tables['h2'].loc[phen, 'Ratio'] = hsqhat.ratio 
+            tables['h2'].loc[phen, 'Ratio_SE'] = hsqhat.ratio_se
+
+    return tables
+
+def write_rg_table(args, RG, n_pheno, rg_files, sumstats_list):
+
+    logging.info('Formatting heritability estimates ...')
+    tables = dict()
+    pd.options.display.float_format = '{:.3f}'.format
+    tables['h2'] = pd.DataFrame(index=rg_files)
+
+    for i, phen in enumerate(rg_files):
+        ldsc_result = RG[i,i]
+        tables['h2'].loc[phen, 'SNPs (M)'] = len(sumstats_list[i])   
+        tables['h2'].loc[phen, 'h2'] =  ldsc_result.hsq1.tot
+        tables['h2'].loc[phen, 'h2_se'] = ldsc_result.hsq1.tot_se
+        tables['h2'].loc[phen, 'lambda GC'] = ldsc_result.hsq1.lambda_gc
+        tables['h2'].loc[phen, 'Mean chi2'] = ldsc_result.hsq1.mean_chisq
+        tables['h2'].loc[phen, 'Intercept'] = ldsc_result.hsq1.intercept
+        tables['h2'].loc[phen, 'Intercept_se'] = ldsc_result.hsq1.intercept_se
+        if not args.no_intercept and (args.intercept_h2 is None) and (args.intercept_gencov is None):
+            tables['h2'].loc[phen, 'Ratio'] = ldsc_result.hsq1.ratio 
+            tables['h2'].loc[phen, 'Ratio_SE'] = ldsc_result.hsq1.ratio_se
+
+    logging.info('Formatting genetic correlation estimates...')
+    tables['rg'] = pd.DataFrame(index=rg_files)
+    for i, phen1 in enumerate(rg_files): 
+        for j, phen2 in enumerate(rg_files):
+            if i == j: 
+                tables['rg'].loc[phen1,phen2] = '1'
+            else:
+                tables['rg'].loc[phen1,phen2] = '{:.3f} ({:.3f})'.format(RG[i,j].rg_ratio, RG[i,j].rg_se)
+
+    tables['cov'] = pd.DataFrame(index=rg_files)
+    for i, phen1 in enumerate(rg_files): 
+        for j, phen2 in enumerate(rg_files):
+                tables['cov'].loc[phen1,phen2] = '{:.3f} ({:.3f})'.format(RG[i,j].gencov.tot, RG[i,j].gencov.tot_se)
+
+    return tables
+
+def print_cov(args, tables, H2=None, RG=None, h2_files=None, rg_files=None):
+    logging.info('Formatting estimation covariances...')
+
+    if H2 is not None:
+        tables['est_cov'] = pd.DataFrame(index=h2_files)
+        for i, phen in enumerate(h2_files):
+            tables['est_cov'].loc[phen, 'est_cov'] = H2[i].coef_cov.flatten()
+
+    if RG is not None:    
+        result_hsq1_cov = matrix_formatter(RG, '.hsq1.coef_cov')
+        result_gencov_cov = matrix_formatter(RG, '.gencov.coef_cov')
+        tables['est_cov'] = pd.DataFrame(index=rg_files)
+
+        for i, phen1 in enumerate(rg_files): 
+            for j, phen2 in enumerate(rg_files):
+                if i == j:
+                    tables['est_cov'].loc[phen1,phen2] = result_hsq1_cov[i,j]
+                else:
+                    tables['est_cov'].loc[phen1,phen2] = result_gencov_cov[i,j]
+
+    tables['est_cov'].to_csv(args.out + '_est_cov.txt', sep='\t', index=False)
+    return tables
+
+def print_delete_vals(args, tables, H2=None, RG=None, h2_files=None, rg_files=None):
+    logging.info('Formatting block jackknife delete-values...')
+    if H2 is not None:
+        
+        tables['est_del'] = pd.DataFrame(columns=h2_files, index=np.arange(args.n_blocks))
+        tables['part_del'] = pd.DataFrame(columns=h2_files, index=np.arange(args.n_blocks))
+
+        for i, phen in enumerate(h2_files):
+            hsqhat = H2[i]
+            est_del = {'Del_Val': hsqhat.tot_delete_values.flatten()}
+            part_del = {'Part_Del_Val': hsqhat.part_delete_values.flatten()}
+            tables['est_del'][phen] = pd.DataFrame(data=est_del)
+            tables['part_del'][phen] = pd.DataFrame(data=part_del)
+            _print_part_delete_values(hsqhat, args.out + '.part_delete')
+
+        tables['est_del'].to_csv(args.out + '.del_val', sep='\t', index=False)
+        tables['part_del'].to_csv(args.out + '.part_del_val', sep='\t', index=False)
+
+    if RG is not None:
+        result_hsq1_del = matrix_formatter(RG, '.hsq1.tot_delete_values')
+        result_gencov_del = matrix_formatter(RG, '.gencov.tot_delete_values')
+        comb_tags = list(it.combinations_with_replacement(rg_files,2))
+        tables['est_del'] = pd.DataFrame(columns=np.array(comb_tags),index=np.arange(args.n_blocks))
+
+        for i, phen1 in enumerate(rg_files): 
+            for j, phen2 in enumerate(rg_files):
+                if i < j:
+                    tables['est_del'].loc[:,comb_tags[int(i*len(rg_files)-i*(i-1)/2+j-i)]] = result_hsq1_del[i,j]
+                else:
+                    tables['est_del'].loc[:,comb_tags[int(j*len(rg_files)-j*(j-1)/2+i-j)]] = result_gencov_del[i,j]
+
+        tables['est_del'].to_csv(args.out + '.del_val', sep='\t', index=False)
+
+    return tables
+
+def matrix_formatter(result_rg, output_var):
+    ''' Key Arguments:
+    result_rg - matrix w/ rghat objects obtained from estimate_rg
+    output_var - interested variable in the form of '.[VAR_NAME]'
+    '''
+    output_mat = np.empty_like(result_rg)
+    (nrow, ncol) = result_rg.shape
+    for i in range(nrow):
+        for j in range(ncol):
+            if result_rg[i, j] is None:
+                output_mat[i, j] = None
+            else:
+                exec('output_mat[i, j] = result_rg[i, j]{}'.format(output_var))
+    return(output_mat)
+
+def _read_other_sumstats(args, fh2, sumstats, ref_ld_cnames, i, k):
+    if i > k:
+        if type(fh2) == pd.DataFrame:
+            loop = fh2.dropna(how='any')
+        else:
+            loop = _read_sumstats(args, fh2, alleles=True, dropna=True)
+        loop = _merge_sumstats_sumstats(args, sumstats, loop)
+    else:
+        loop = sumstats.copy()
+        loop['A1x'] = sumstats.A1
+        loop['A2x'] = sumstats.A2
+        loop['N2'] = sumstats.N
+        loop['Z2'] = sumstats.Z
+        loop.rename(columns={'N':'N1','Z':'Z1'}, inplace=True)
+
     alleles = loop.A1 + loop.A2 + loop.A1x + loop.A2x
     if not args.no_check_alleles:
-        loop = _select_and_log(loop, _filter_alleles(alleles), log,
+        loop = _select_and_log(loop, _filter_alleles(alleles),
                                '{N} SNPs with valid alleles.')
-
     loop['Z2'] = _align_alleles(loop.Z2, alleles)
     loop = loop.drop(['A1', 'A1x', 'A2', 'A2x'], axis=1)
-    _check_ld_condnum(args, log, loop[ref_ld_cnames])
-    _warn_length(log, loop)
+    _check_ld_condnum(args, loop[ref_ld_cnames])
+    _warn_length(loop)
+
     return loop
 
-
-def _get_rg_table(rg_paths, RG, args):
+def _get_rg_table(rg_files, RG, args):
     '''Print a table of genetic correlations.'''
     t = lambda attr: lambda obj: getattr(obj, attr, 'NA')
     x = pd.DataFrame()
-    x['p1'] = [rg_paths[0] for i in xrange(1, len(rg_paths))]
-    x['p2'] = rg_paths[1:len(rg_paths)]
+    x['p1'] = [rg_files[i][0] for i in range(len(RG))]
+    x['p2'] = [rg_path_tups[i][1] for i in range(len(RG))]
     x['rg'] = map(t('rg_ratio'), RG)
     x['se'] = map(t('rg_se'), RG)
     x['z'] = map(t('z'), RG)
@@ -471,33 +714,37 @@ def _get_rg_table(rg_paths, RG, args):
     x['gcov_int_se'] = map(t('intercept_se'), map(t('gencov'), RG))
     return x.to_string(header=True, index=False) + '\n'
 
-
-def _print_gencor(args, log, rghat, ref_ld_cnames, i, rg_paths, print_hsq1):
+def _print_gencor(args, rghat, ref_ld_cnames, i1,i2, rg_paths, print_hsq1):
     l = lambda x: x + ''.join(['-' for i in range(len(x.replace('\n', '')))])
-    P = [args.samp_prev[0], args.samp_prev[i + 1]]
-    K = [args.pop_prev[0], args.pop_prev[i + 1]]
+    P = [args.samp_prev[i1], args.samp_prev[i2]]
+    K = [args.pop_prev[i1], args.pop_prev[i2]]
     if args.samp_prev is None and args.pop_prev is None:
         args.samp_prev = [None, None]
         args.pop_prev = [None, None]
     if print_hsq1:
-        log.log(l('\nHeritability of phenotype 1\n'))
-        log.log(rghat.hsq1.summary(ref_ld_cnames, P=P[0], K=K[0]))
+        logging.info(l('\nHeritability of phenotype {I}/{N}\n'.format(I=i1+1, N=len(rg_paths))))
+        logging.info(rghat.hsq1.summary(ref_ld_cnames, P=P[0], K=K[0]))
 
-    log.log(
-        l('\nHeritability of phenotype {I}/{N}\n'.format(I=i + 2, N=len(rg_paths))))
-    log.log(rghat.hsq2.summary(ref_ld_cnames, P=P[1], K=K[1]))
-    log.log(l('\nGenetic Covariance\n'))
-    log.log(rghat.gencov.summary(ref_ld_cnames, P=P, K=K))
-    log.log(l('\nGenetic Correlation\n'))
-    log.log(rghat.summary() + '\n')
+    logging.info(
+        l('\nHeritability of phenotype {I}/{N}\n'.format(I=i2+1, N=len(rg_paths))))
+    logging.info(rghat.hsq2.summary(ref_ld_cnames, P=P[1], K=K[1]))
+    logging.info(l('\nGenetic Covariance\n'))
+    logging.info(rghat.gencov.summary(ref_ld_cnames, P=P, K=K))
+    logging.info(l('\nGenetic Correlation\n'))
+    logging.info(rghat.summary() + '\n')
 
+def _print_h2(args, hsqhat, ref_ld_cnames, i1, n_pheno):
+    l = lambda x: x + ''.join(['-' for i in range(len(x.replace('\n', '')))])
+    logging.info(
+        l('\nHeritability of phenotype {I}/{N}\n'.format(I=i1+1, N=n_pheno)))
+    logging.info(hsqhat.summary(ref_ld_cnames, P=args.samp_prev, K=args.pop_prev, overlap = args.overlap_annot) + '\n')
 
-def _merge_sumstats_sumstats(args, sumstats1, sumstats2, log):
+def _merge_sumstats_sumstats(args, sumstats1, sumstats2):
     '''Merge two sets of summary statistics.'''
     sumstats1.rename(columns={'N': 'N1', 'Z': 'Z1'}, inplace=True)
     sumstats2.rename(
         columns={'A1': 'A1x', 'A2': 'A2x', 'N': 'N2', 'Z': 'Z2'}, inplace=True)
-    x = _merge_and_log(sumstats1, sumstats2, 'summary statistics', log)
+    x = _merge_and_log(sumstats1, sumstats2, 'summary statistics')
     return x
 
 
@@ -517,8 +764,7 @@ def _align_alleles(z, alleles):
         raise KeyError(msg)
     return z
 
-
-def _rg(sumstats, args, log, M_annot, ref_ld_cnames, w_ld_cname, i):
+def _rg(sumstats, args, M_annot, ref_ld_cnames, w_ld_cname, i1, i2):
     '''Run the regressions.'''
     n_snp = len(sumstats)
     s = lambda x: np.array(x).reshape((n_snp, 1))
@@ -528,8 +774,7 @@ def _rg(sumstats, args, log, M_annot, ref_ld_cnames, w_ld_cname, i):
         sumstats = sumstats[ii]
     n_blocks = min(args.n_blocks, n_snp)
     ref_ld = sumstats.as_matrix(columns=ref_ld_cnames)
-    intercepts = [args.intercept_h2[0], args.intercept_h2[
-        i + 1], args.intercept_gencov[i + 1]]
+    intercepts = [args.intercept_h2[i1], args.intercept_h2[i2], args.intercept_gencov[i2]]
     rghat = reg.RG(s(sumstats.Z1), s(sumstats.Z2),
                    ref_ld, s(sumstats[w_ld_cname]), s(
                        sumstats.N1), s(sumstats.N2), M_annot,
@@ -539,38 +784,34 @@ def _rg(sumstats, args, log, M_annot, ref_ld_cnames, w_ld_cname, i):
     return rghat
 
 
-def _parse_rg(rg):
+def _parse_(filepaths):
     '''Parse args.rg.'''
-    rg_paths = _splitp(rg)
-    rg_files = [x.split('/')[-1] for x in rg_paths]
-    if len(rg_paths) < 2:
-        raise ValueError(
-            'Must specify at least two phenotypes for rg estimation.')
+    paths = _splitp(filepaths)
+    files = [x.split('/')[-1] for x in paths]
 
-    return rg_paths, rg_files
+    return paths, files
 
 
-def _print_rg_delete_values(rg, fh, log):
+def _print_rg_delete_values(rg, fh):
     '''Print block jackknife delete values.'''
-    _print_delete_values(rg.hsq1, fh + '.hsq1.delete', log)
-    _print_delete_values(rg.hsq2, fh + '.hsq2.delete', log)
-    _print_delete_values(rg.gencov, fh + '.gencov.delete', log)
+    _print_delete_values(rg.hsq1, fh + '.hsq1.delete')
+    _print_delete_values(rg.hsq2, fh + '.hsq2.delete')
+    _print_delete_values(rg.gencov, fh + '.gencov.delete')
 
 
-def _print_rg_cov(rghat, fh, log):
+def _print_rg_cov(rghat, fh):
     '''Print covariance matrix of estimates.'''
-    _print_cov(rghat.hsq1, fh + '.hsq1.cov', log)
-    _print_cov(rghat.hsq2, fh + '.hsq2.cov', log)
-    _print_cov(rghat.gencov, fh + '.gencov.cov', log)
+    _print_cov(rghat.hsq1, fh + '.hsq1.cov')
+    _print_cov(rghat.hsq2, fh + '.hsq2.cov')
+    _print_cov(rghat.gencov, fh + '.gencov.cov')
 
 
 def _split_or_none(x, n):
     if x is not None:
         y = map(float, x.replace('N', '-').split(','))
     else:
-        y = [None for _ in xrange(n)]
+        y = [None for _ in range(n)]
     return y
-
 
 def _check_arg_len(x, n):
     x, m = x

--- a/ldscore/sumstats.py
+++ b/ldscore/sumstats.py
@@ -350,7 +350,7 @@ def estimate_h2(args):
     H2 = []
     sumstats_list = {}
 
-    if type(args.h2) == str: # command line case
+    if isinstance(args.h2, str): # command line case
         h2_paths, h2_files = _parse_(args.h2) # rows
         h2_list = h2_paths # columns
         n_pheno = len(h2_paths)
@@ -369,7 +369,7 @@ def estimate_h2(args):
 
         ref_ld, w_ld, M_annot, ref_ld_cnames, novar_cols=map(lambda x: x.copy(),(ref_ld_orig, w_ld_orig, M_annot_orig, ref_ld_cnames_orig, novar_cols_orig))
 
-        if type(args.h2) == str:
+        if isinstance(args.h2, str):
             p1 = p1_orig
         else:
             p1 = p1_orig.copy()
@@ -450,7 +450,7 @@ def estimate_rg(args):
     RG = []
     sumstats_list = {}
 
-    if type(args.rg) == str: # command line case
+    if isinstance(args.rg, str): # command line case
         rg_paths, rg_files = _parse_(args.rg) # rows
         rg_list = rg_paths # columns
         n_pheno = len(rg_paths)
@@ -477,7 +477,7 @@ def estimate_rg(args):
         
     for k, p1_orig in enumerate(rg_list): # rows
 
-        if type(args.rg) == str:
+        if isinstance(args.rg, str):
             p1 = p1_orig 
         else:
             p1 = p1_orig.copy()

--- a/munge_sumstats.py
+++ b/munge_sumstats.py
@@ -511,7 +511,7 @@ filters.add_argument('--daner', default=False, action='store_true',
                     help="Use this flag to parse Stephan Ripke's daner* file format.")
 filters.add_argument('--daner-n', default=False, action='store_true',
                     help="Use this flag to parse more recent daner* formatted files, which "
-            "include sample size column 'Nca' and 'Nco'.")
+                    "include sample size column 'Nca' and 'Nco'.")
 filters.add_argument('--merge-alleles', default=None, type=str,
                     help="Same as --merge, except the file should have three columns: SNP, A1, A2, "
                     "and all alleles will be matched to the --merge-alleles file alleles.")


### PR DESCRIPTION
Here are brief descriptions of our changes:

## Major Changes
- **Pandas dataframes can now be passed directly to LDSC with direct calls from Python.**
  * _Implemented in script `ldscore.sumstats.py` lines [353-363, 453-463]_
  * While the original `bulik/ldsc` is callable from command line, we attempted to make it more flexible so that functions can be called directly in Python. Specifically, we modified the `estimate_h2` and `estimate_rg` functions which now “recognize” the running environment. If the summary statistics are already provided in the format of pandas dataframes (in Python), `ldsc` will input them directly without going through the import & read steps. The parsing functionality is retained but is reserved for calling LDSC via command line.  
- **--rg now calculates pairwise genetic correlations for all traits.**
  * _Implemented in script `ldscore.sumstats.py` lines [478-509] (for-loops)_
  * The current `bulik/ldsc` can run multiple bivariate LDSC at the same time, but it only estimates the genetic correlations between _one_ trait and a list of other traits. We extended this function to allow for pairwise estimation across _all_ traits. The results will be stored in a matrix object, which is returned by `estimate_rg`, along with a list of tables containing rg-related statistics. More updates to the output options are discussed below. 
- **`--h2` can now run univariate LDSC on a list of traits sequentially.**
  * _Implemented in script `ldscore.sumstats.py` lines [368-412] (for loops)_
  * The updated `ldsc` package can take in multiple summary statistics using a single command and estimate the heritability for each of the traits sequentially. The results are conveniently stored in a list of tables containing h2-related statistics. Users may choose to view (and operate on) these estimates directly in Python or write them to files. 
- **Estimate results from `h2` and `rg` can be printed to .txt or excel tables.**
  * _Implemented in script `ldscore.sumstats.py` functions: `write_h2_table`, `write_rg_table`, `print_estimates`, `print_cov` and `print_delete_vals`. Also reflected in script `ldsc.py`, new flags `--write-excel` and `--print-estimates`_
  * We added four output options (argument group “Output Options”) so that the estimate results can be presented based on users’ preferences.
- **`ldsc` can now exclude a list of SNPs when running LDSC regressions.**
  * _Implemented in script `ldscore.sumstats.py` lines [265-273]. Also reflected in script `ldsc.py`, new flag `--exclude`_
  * This new option may be useful when performing sensitivity analysis that requires excluding SNPs from a high effect locus without having to generate a new set of summary statistics first. 
- **The LD reference data is read in only once, which can lead to substantial improvement in runtime when analyzing multiple traits.** 
  * _Implemented in script `ldscore.sumstats.py` functions `_read_ref`, `_read_ld_sumstats`, and places wherever they are called_
  * We removed redundant readings of the reference panels, by importing the LD score data only once throughout the analysis. This significantly saves the `ldsc` runtime without influencing the estimate results.
- **`--two-step ` is set to infinity by default.**
  * _Implemented in script `ldscore.sumstats.py` lines [389-390, 490-491]_
  * The current package by default imposes a cutoff value of 30 on the test statistic in two-step estimation. We removed this limit by setting its default value to infinity. As a result, SNPs with high chi^2 values are no longer filtered out.
- **Useful objects related to allele relationships are stored in a separate module `allele_info.py`**
  * _Implemented in script `allele_info.py`_

## Minor Changes
- **`--ref-ld` will use the reference panel from `--w-ld` if it is not specified (and vice versa).**
  * _Implemented in script `ldsc.py` lines [651-665]_
  * Only one of `--ref-ld` and `--w-ld` is required, unless the flag `--overlap-annot` is specified.
- **The logging module is used to create log files and stream output to console.**
  * _Implemented across scripts_
- **The argument options in `ldsc.py` are now organized into groups by functionality.**
  * _Implemented in script `ldsc.py` lines [409-595]_

Please direct any questions/comments to Omeed Maghzian (maghzian@nber.org), Hui Li (huilieatpraylove@gmail.com), and Sean Lee (seanclee@nber.org).