### PR TITLE
added shebang to make_annot.py

### DIFF
--- a/make_annot.py
+++ b/make_annot.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 import pandas as pd
 import numpy as np


### PR DESCRIPTION
I have ldsc installed on a cluster, and we use modules to load software to our paths dynamically, and without a shebang in the file, the module wont work as the script is run as a bash file or the full path needs to be provided.

This pull request adds a shebang to the make_annots.py file.