### PR TITLE
Rg liab

### DIFF
--- a/ldscore/regressions.py
+++ b/ldscore/regressions.py
@@ -568,7 +568,7 @@ class Gencov(LD_Score_Regression):
             c = 1
 
         out.append('Total ' + T + ' scale gencov: ' +
-                   s(self.tot) + ' (' + s(self.tot_se) + ')')
+                   s(c * self.tot) + ' (' + s(c * self.tot_se) + ')')
         if self.n_annot > 1:
             out.append('Categories: ' + str(' '.join(ref_ld_colnames)))
             out.append(T + ' scale gencov: ' + s(c * self.cat))

--- a/ldscore/sumstats.py
+++ b/ldscore/sumstats.py
@@ -455,12 +455,14 @@ def _get_rg_table(rg_paths, RG, args):
     x['se'] = map(t('rg_se'), RG)
     x['z'] = map(t('z'), RG)
     x['p'] = map(t('p'), RG)
-    if args.samp_prev is not None and args.pop_prev is not None and\
-            all((i is not None for i in args.samp_prev)) and all((i is not None for it in args.pop_prev)):
-        c = reg.h2_obs_to_liab(1, args.samp_prev[1], args.pop_prev[1])
-        x['h2_liab'] = map(lambda x: c * x, map(t('tot'), map(t('hsq2'), RG)))
-        x['h2_liab_se'] = map(
-            lambda x: c * x, map(t('tot_se'), map(t('hsq2'), RG)))
+    if args.samp_prev is not None and \
+            args.pop_prev is not None and \
+            all((i is not None for i in args.samp_prev)) and \
+            all((i is not None for it in args.pop_prev)):
+
+        c = map(lambda x, y: reg.h2_obs_to_liab(1, x, y), args.samp_prev[1:], args.pop_prev[1:])
+        x['h2_liab'] = map(lambda x, y: x * y, c, map(t('tot'), map(t('hsq2'), RG)))
+        x['h2_liab_se'] = map(lambda x, y: x * y, c, map(t('tot_se'), map(t('hsq2'), RG)))
     else:
         x['h2_obs'] = map(t('tot'), map(t('hsq2'), RG))
         x['h2_obs_se'] = map(t('tot_se'), map(t('hsq2'), RG))


### PR DESCRIPTION
Addresses two issues with reporting liability-scale heritability and covariance results in `--rg` analyses:

* Previously, genetic covariance results reported in the running log would always be reported on the observed scale, even if sample and population prevalences had been included in the arguments. This was true even when the text of the log stated that the value was the liability-scale genetic covariance. A fix for this issue previously existed on github branch `liability_gencov`. 

* Previously, in `--rg` analyses with > 2 phenotypes, if liability scale estimates were requested (i.e. `--samp-prev` and `--pop-prev` were specified), the final summary table would report liability scale heritability estimates based on the prevalence of the second phenotype in the `--rg` list, rather than using the corresponding prevalence for each phenotype. The correct liability-scale h2 estimate was however reported in the running log, e.g. in the blocks that look like this:

```
Heritability of phenotype 2/4
-----------------------------
Total Liability scale h2: 0.2882 (0.0293)
Lambda GC: 1.1364
Mean Chi^2: 1.1436
Intercept: 1.0013 (0.0094)
Ratio: 0.0093 (0.0652)
```

Neither of these issues would have affected inference for whether the h2 or covariance differs from zero, since the reported SEs for the affected h2 and covariance values were reported on the same scale as the point estimate. Only interpretation of the point estimates would be potentially impacted, and only if interpreting the genetic covariance (i.e. rg estimates unaffected) or using the liability h2 values from the `--rg` summary table rather than running `--rg` analyses.

Thanks to Andrew Grotzinger, Eske Derks, Jackson Thorpe, and others for helping identify this issue and confirm the fixes in this pull request.

*Note:* Changelog needs to be updated before merging this pull request. Will do so now.
