### PR TITLE
Improve consistency of unit test Hsq_2D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ docs/_build/
 *cov
 *.sumstats
 *.delete_k
+*.part_delete
 *asdf*
 *qwer*
 *M_5_50*

--- a/test/test_regressions.py
+++ b/test/test_regressions.py
@@ -194,7 +194,8 @@ class Test_Hsq_2D(unittest.TestCase):
     def test_summary(self):
         # not much to test; we can at least make sure no errors at runtime
         self.hsq.summary(['asdf', 'qwer'])
-        self.ld += np.arange(17).reshape((17, 1))
+	# change to random 7/30/2019 to avoid inconsistent singular matrix errors
+        self.ld += np.random.normal(scale=0.1, size=(17,2))
         self.chisq += np.arange(17).reshape((17, 1))
         hsq = reg.Hsq(
             self.chisq, self.ld, self.w_ld, self.N, self.M, n_blocks=3)


### PR DESCRIPTION
In testing, `Test_Hsq_2D` fails inconsistently on the current `master` branch even when using the conda environment specified by `environment.yml`. The failing is caused by trying to `solve()` a singular matrix: 

```
======================================================================
ERROR: test_summary (test_regressions.Test_Hsq_2D)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/unix/rwalters/github/ldsc/test/test_regressions.py", line 200, in test_summary
    self.chisq, self.ld, self.w_ld, self.N, self.M, n_blocks=3)
  File "/home/unix/rwalters/github/ldsc/ldscore/regressions.py", line 346, in __init__
    slow=slow, step1_ii=step1_ii, old_weights=old_weights)
  File "/home/unix/rwalters/github/ldsc/ldscore/regressions.py", line 213, in __init__
    x, yp, update_func, n_blocks, slow=slow, w=initial_w)
  File "/home/unix/rwalters/github/ldsc/ldscore/irwls.py", line 66, in __init__
    x, y, update_func, n_blocks, w, slow=slow, separators=separators)
  File "/home/unix/rwalters/github/ldsc/ldscore/irwls.py", line 127, in irwls
    x, y, n_blocks, separators=separators)
  File "/home/unix/rwalters/github/ldsc/ldscore/jackknife.py", line 309, in __init__
    self.est = self.block_values_to_est(xty, xtx)
  File "/home/unix/rwalters/github/ldsc/ldscore/jackknife.py", line 386, in block_values_to_est
    return np.linalg.solve(xtx, xty).reshape((1, p))
  File "/home/unix/rwalters/.conda/envs/ldsc/lib/python2.7/site-packages/numpy/linalg/linalg.py", line 384, in solve
    r = gufunc(a, b, signature=signature, extobj=extobj)
  File "/home/unix/rwalters/.conda/envs/ldsc/lib/python2.7/site-packages/numpy/linalg/linalg.py", line 90, in _raise_linalgerror_singular
    raise LinAlgError("Singular matrix")
LinAlgError: Singular matrix
```

The test does indeed set up a singular matrix. The reason the test doesn't fail consistently is unclear. In either case, the unit test being performed doesn't rely on having a singular matrix, so the simplest solution to ensure the test works as intended appears to be to change the test to avoid a singular matrix.