### PR TITLE
Do not perform `_align_alleles` when `--no-check-alleles` is specified.

### DIFF
--- a/ldscore/sumstats.py
+++ b/ldscore/sumstats.py
@@ -437,8 +437,8 @@ def _read_other_sumstats(args, log, p2, sumstats, ref_ld_cnames):
     if not args.no_check_alleles:
         loop = _select_and_log(loop, _filter_alleles(alleles), log,
                                '{N} SNPs with valid alleles.')
+        loop['Z2'] = _align_alleles(loop.Z2, alleles)
 
-    loop['Z2'] = _align_alleles(loop.Z2, alleles)
     loop = loop.drop(['A1', 'A1x', 'A2', 'A2x'], axis=1)
     _check_ld_condnum(args, log, loop[ref_ld_cnames])
     _warn_length(log, loop)


### PR DESCRIPTION
When using `--rg` with `--no-check-alleles` option, I don't think we need to `_align_alleles` between the sumstats since we know they're perfectly aligned. It causes an error when sumstats has e.g., strand ambiguous SNPs, displaying a mysterious error message:
```
KeyError: 'Incompatible alleles in .sumstats files: TATA. Did you forget to use --merge-alleles with munge_sumstats.py?'
```

It sounded like the error was because of some `TATA` alleles... but in fact `TATA` represents A1 + A2 + A1 complement + A2 complement...

@julirsch