### PR TITLE
fixed a bug in make_annot.py

### DIFF
--- a/make_annot.py
+++ b/make_annot.py
@@ -13,17 +13,17 @@ def gene_set_to_bed(args):
     df = pd.merge(GeneSet, all_genes, on = 'GENE', how = 'inner')
     df['START'] = np.maximum(0, df['START'] - args.windowsize)
     df['END'] = df['END'] + args.windowsize
-    iter_df = [['chr'+(str(x1).lstrip('chr')), x2, x3] for (x1,x2,x3) in np.array(df[['CHR', 'START', 'END']])]
+    iter_df = [['chr'+(str(x1).lstrip('chr')), x2 - 1, x3] for (x1,x2,x3) in np.array(df[['CHR', 'START', 'END']])]
     return BedTool(iter_df).sort().merge()
 
 def make_annot_files(args, bed_for_annot):
     print('making annot file')
     df_bim = pd.read_csv(args.bimfile,
             delim_whitespace=True, usecols = [0,1,2,3], names = ['CHR','SNP','CM','BP'])
-    iter_bim = [['chr'+str(x1), x2, x2] for (x1, x2) in np.array(df_bim[['CHR', 'BP']])]
+    iter_bim = [['chr'+str(x1), x2 - 1, x2] for (x1, x2) in np.array(df_bim[['CHR', 'BP']])]
     bimbed = BedTool(iter_bim)
     annotbed = bimbed.intersect(bed_for_annot)
-    bp = [x.start for x in annotbed]
+    bp = [x.start + 1 for x in annotbed]
     df_int = pd.DataFrame({'BP': bp, 'ANNOT':1})
     df_annot = pd.merge(df_bim, df_int, how='left', on='BP')
     df_annot.fillna(0, inplace=True)


### PR DESCRIPTION
#### Description 
Fixed a bug in `make_annot.py`. This bug is due to the mismatch between 0-based and 1-based coordinate objects, and can result in incorrect annotation. In the current code (bug not fixed), `BedTool(iter_df).sort().merge()`, `bimbed` and `annotbed` are `bed` file type objects (using 0-based coordinate), but values in them stored as 1-based coordinate format. If adding the following code below the `bimbed = BedTool(iter_bim)`, we can see the mismatch.
```
print(bimbed.file_type) # file type: bed
print(bimbed.head(5))   # values saved as 1-based coordinate format
```
#### Steps to reproduce this bug
##### Test 1
1. We need `1000G.EUR.QC.22.bim` downloaded from [1000G\_Phase3\_plinkfiles.tgz](https://data.broadinstitute.org/alkesgroup/LDSCORE/1000G\_Phase3\_plinkfiles.tgz).
It has 141123 rows, but we just need to look at these 5 rows:
```
22	rs67102	2.2447927	16876305	T	C
22	rs5748409	2.2452285	16876565	A	T
22	rs131556	2.2452302	16876566	A	T
22	rs562864284	2.2452319	16876567	T	A
22	rs9606148	2.2452621	16876585	A	G
```
2. We also need 2 files as following:

`cell1.snpset` :
```
GENE
rs131556
```
`SNP_1-based_coord.txt` :
```
GENE	CHR	START	END
rs131556	chr22	16876566	16876566
```
3. Run the code:
```
python make_annot.py \
--gene-set-file cell1.snpset \
--gene-coord-file SNP_1-based_coord.txt \
--windowsize 0 \
--bimfile 1000G.EUR.QC.22.bim \
--annot-file cell1.annot 
```
##### Test 2
1. We need `1000G.EUR.QC.22.bim`.
2. We also need the following file: 

`geneA.bed`:
```
chr22	16876567	16876580
```
3. Run the code:
```
python make_annot.py \
--bed-file geneA.bed \
--windowsize 0 \
--bimfile 1000G.EUR.QC.22.bim \
--annot-file geneA.annot 
```
#### Actual results (bug)
##### Actual result of test 1 (bug)
Three occurrences of `1` in `cell1.annot` (rs5748409, rs131556 and rs562864284 in `1000G.EUR.QC.22.bim` are annoted as `1`)
##### Actual result of test 2 (bug)
One occurrence of `1` in `geneA.annot` (rs562864284 in `1000G.EUR.QC.22.bim` is annoted as `1`)
#### Expected results (correct)
##### Expected result of test 1 (correct)
One occurrence of `1` in `cell1.annot` (only rs131556 should be annoted as `1`)\
Explain:
Both the `SNP_1-based_coord.txt` and `1000G.EUR.QC.22.bim` use 1-based coordinate system, and only rs131556 in `1000G.EUR.QC.22.bim` is at the region of `cell1.snpset`, so only one SNP should be annoted as `1`.
##### Expected result of test 2 (correct)
No occurrence of `1` in `geneA.annot`\
Explain:
The `.bed` uses 0-based coordinate system, while `.bim` uses 1-based coordinate system. 
The `geneA.bed` shows that the 0-based coordinate of `geneA` is [16876567, 16876580). And when using 1-based coordinate system, the 1-based coordinate of `geneA` is [16876568, 16876580]. So, all SNPs in `1000G.EUR.QC.22.bim` are not at the region of  `geneA` and they should be annoted as `0`.
#### Environment INFO
Platform: linux-64\
Packages: as same as the packages in ldsc [environment.yml](https://github.com/bulik/ldsc/blob/master/environment.yml).
```
python                    2.7.15
bitarray                  0.8.3
nose                      1.3.7
pybedtools                0.7.10
scipy                     0.18.1
pandas                    0.20.3
numpy                     1.12.1
```