### PR TITLE
Find matching files with glob to allow wildcards

### DIFF
--- a/ldscore/sumstats.py
+++ b/ldscore/sumstats.py
@@ -17,6 +17,7 @@ import sys
 import traceback
 import copy
 import os
+import glob
 
 
 _N_CHR = 22
@@ -50,8 +51,10 @@ FLIP_ALLELES = {''.join(x):
 
 def _splitp(fstr):
     flist = fstr.split(',')
-    flist = [os.path.expanduser(os.path.expandvars(x)) for x in flist]
-    return flist
+    paths = []
+    for x in [os.path.expanduser(os.path.expandvars(x)) for x in flist]:
+      paths.extend(glob.glob(x))
+    return paths
 
 
 def _select_and_log(x, ii, log, msg):


### PR DESCRIPTION
The specific use-case I have in mind is so that I can pass in a folder to LDSC with a variable number of chromosomes and LDSC will use whatever chromosomes it sees inside (if I pass in a wildcard).