### PR TITLE
fix make_annot bug

### DIFF
--- a/make_annot.py
+++ b/make_annot.py
@@ -11,7 +11,7 @@ def gene_set_to_bed(args):
     GeneSet = pd.read_csv(args.gene_set_file, header = None, names = ['GENE'])
     all_genes = pd.read_csv(args.gene_coord_file, delim_whitespace = True)
     df = pd.merge(GeneSet, all_genes, on = 'GENE', how = 'inner')
-    df['START'] = np.maximum(0, df['START'] - args.windowsize)
+    df['START'] = np.maximum(1, df['START'] - args.windowsize)
     df['END'] = df['END'] + args.windowsize
     iter_df = [['chr'+(str(x1).lstrip('chr')), x2 - 1, x3] for (x1,x2,x3) in np.array(df[['CHR', 'START', 'END']])]
     return BedTool(iter_df).sort().merge()


### PR DESCRIPTION
As `geneset` files are using 1-based coordinate system,  their start position should be >= 1. Otherwise, it may store negative values in `bed` file (when converting 1-based to 0-based coordinate by `line 16`, `x2 - 1` could be negative values ) and raise an error.

It was reported by #198 and #194 @roshchupkin 