### PR TITLE
Fix globbing bug in splitp

### DIFF
--- a/ldscore/parse.py
+++ b/ldscore/parse.py
@@ -118,9 +118,9 @@ def ldscore(fh, num=None):
     '''Parse .l2.ldscore files, split across num chromosomes. See docs/file_formats_ld.txt.'''
     suffix = '.l2.ldscore'
     if num is not None:  # num files, e.g., one per chromosome
-        first_fh = sub_chr(fh, 1) + suffix
-        s, compression = which_compression(first_fh)
         chrs = get_present_chrs(fh, num+1)
+        first_fh = sub_chr(fh, chrs[0]) + suffix
+        s, compression = which_compression(first_fh)
         chr_ld = [l2_parser(sub_chr(fh, i) + suffix + s, compression) for i in chrs]
         x = pd.concat(chr_ld)  # automatically sorted by chromosome
     else:  # just one file
@@ -187,8 +187,9 @@ def annot(fh_list, num=None, frqfile=None):
     annot_suffix = ['.annot' for fh in fh_list]
     annot_compression = []
     if num is not None:  # 22 files, one for each chromosome
+        chrs = get_present_chrs(fh, num+1)
         for i, fh in enumerate(fh_list):
-            first_fh = sub_chr(fh, 1) + annot_suffix[i]
+            first_fh = sub_chr(fh, chrs[0]) + annot_suffix[i]
             annot_s, annot_comp_single = which_compression(first_fh)
             annot_suffix[i] += annot_s
             annot_compression.append(annot_comp_single)
@@ -201,7 +202,7 @@ def annot(fh_list, num=None, frqfile=None):
 
         y = []
         M_tot = 0
-        for chrom in get_present_chrs(fh, num+1):
+        for chrom in chrs:
             if frqfile is not None:
                 df_annot_chr_list = [annot_parser(sub_chr(fh, chrom) + annot_suffix[i], annot_compression[i],
                                                   sub_chr(frqfile, chrom) + frq_suffix, frq_compression)

--- a/ldscore/parse.py
+++ b/ldscore/parse.py
@@ -114,24 +114,6 @@ def ldscore_fromlist(flist, num=None):
     return pd.concat(ldscore_array, axis=1)
 
 
-def ldscore(fh, num=None):
-    '''Parse .l2.ldscore files, split across num chromosomes. See docs/file_formats_ld.txt.'''
-    suffix = '.l2.ldscore'
-    if num is not None:  # num files, e.g., one per chromosome
-        chrs = get_present_chrs(fh, num+1)
-        first_fh = sub_chr(fh, chrs[0]) + suffix
-        s, compression = which_compression(first_fh)
-        chr_ld = [l2_parser(sub_chr(fh, i) + suffix + s, compression) for i in chrs]
-        x = pd.concat(chr_ld)  # automatically sorted by chromosome
-    else:  # just one file
-        s, compression = which_compression(fh + suffix)
-        x = l2_parser(fh + suffix + s, compression)
-
-    x = x.sort_values(by=['CHR', 'BP']) # SEs will be wrong unless sorted
-    x = x.drop(['CHR', 'BP'], axis=1).drop_duplicates(subset='SNP')
-    return x
-
-
 def l2_parser(fh, compression):
     '''Parse LD Score files'''
     x = read_csv(fh, header=0, compression=compression)
@@ -155,6 +137,24 @@ def frq_parser(fh, compression):
     if 'MAF' in df.columns:
         df.rename(columns={'MAF': 'FRQ'}, inplace=True)
     return df[['SNP', 'FRQ']]
+
+
+def ldscore(fh, num=None):
+    '''Parse .l2.ldscore files, split across num chromosomes. See docs/file_formats_ld.txt.'''
+    suffix = '.l2.ldscore'
+    if num is not None:  # num files, e.g., one per chromosome
+        chrs = get_present_chrs(fh, num+1)
+        first_fh = sub_chr(fh, chrs[0]) + suffix
+        s, compression = which_compression(first_fh)
+        chr_ld = [l2_parser(sub_chr(fh, i) + suffix + s, compression) for i in chrs]
+        x = pd.concat(chr_ld)  # automatically sorted by chromosome
+    else:  # just one file
+        s, compression = which_compression(fh + suffix)
+        x = l2_parser(fh + suffix + s, compression)
+
+    x = x.sort_values(by=['CHR', 'BP']) # SEs will be wrong unless sorted
+    x = x.drop(['CHR', 'BP'], axis=1).drop_duplicates(subset='SNP')
+    return x
 
 
 def M(fh, num=None, N=2, common=False):

--- a/ldscore/sumstats.py
+++ b/ldscore/sumstats.py
@@ -50,10 +50,8 @@ FLIP_ALLELES = {''.join(x):
 
 def _splitp(fstr):
     flist = fstr.split(',')
-    paths = []
-    for x in [os.path.expanduser(os.path.expandvars(x)) for x in flist]:
-      paths.extend(glob.glob(x))
-    return paths
+    flist = [os.path.expanduser(os.path.expandvars(x)) for x in flist]
+    return flist
 
 
 def _select_and_log(x, ii, log, msg):

--- a/ldscore/sumstats.py
+++ b/ldscore/sumstats.py
@@ -4,7 +4,6 @@
 This module deals with getting all the data needed for LD Score regression from files
 into memory and checking that the input makes sense. There is no math here. LD Score
 regression is implemented in the regressions module.
-
 '''
 from __future__ import division
 import numpy as np
@@ -147,11 +146,11 @@ def _read_chr_split_files(chr_arg, not_chr_arg, log, noun, parsefunc, **kwargs):
     '''Read files split across 22 chromosomes (annot, ref_ld, w_ld).'''
     try:
         if not_chr_arg:
-            log.log('Reading {N} from {F} ...'.format(F=not_chr_arg, N=noun))
+            log.log('Reading {N} from {F} ... ({p})'.format(N=noun, F=not_chr_arg, p=parsefunc.__name__))
             out = parsefunc(_splitp(not_chr_arg), **kwargs)
         elif chr_arg:
             f = ps.sub_chr(chr_arg, '[1-22]')
-            log.log('Reading {N} from {F} ...'.format(F=f, N=noun))
+            log.log('Reading {N} from {F} ... ({p})'.format(N=noun, F=f, p=parsefunc.__name__))
             out = parsefunc(_splitp(chr_arg), _N_CHR, **kwargs)
     except ValueError as e:
         log.log('Error parsing {N}.'.format(N=noun))


### PR DESCRIPTION
Current globbing is broken (see [#214](https://github.com/bulik/ldsc/issues/214)). This fixes the bug returns the prefix as the original behavior was. It instead checks for file existence in parse.py. It also makes minor code improvements.