### PR TITLE
added alternative name for SNP column

### DIFF
--- a/munge_sumstats.py
+++ b/munge_sumstats.py
@@ -32,6 +32,7 @@ default_cnames = {
 
     # RS NUMBER
     'SNP': 'SNP',
+    'VARIANT_ID': 'SNP',
     'MARKERNAME': 'SNP',
     'SNPID': 'SNP',
     'RS': 'SNP',


### PR DESCRIPTION
I'm working with GWAS summary statistics where the SNP column is called "variant_id", so added that to the dictionary.