### PR TITLE
python2 called explicitly

### DIFF
--- a/ldsc.py
+++ b/ldsc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''
 (c) 2014 Brendan Bulik-Sullivan and Hilary Finucane
 


### PR DESCRIPTION
Hi bulik,

I tried running `ldsc -h` in a Anaconda3 environment (much like [issue #178](https://github.com/bulik/ldsc/issues/178)) and got the following error:

>     ./ldsc.py -h
      File "./ldsc.py", line 84
        print msg
                ^
    SyntaxError: Missing parentheses in call to 'print'. Did you mean print(msg)?

Turns out the problem is that ldsc.py calls python with '#!/usr/bin/env python', which will call either python2 or python3 depending on how a user has set up his python (Anaconda) installation.

This pull request I am sending you today changes the one line above to '#!/usr/bin/env python2'. This solves this issue, i.e. './ldsc.py -h' prints out the list of all command-line options, as intended. I have not tried running ldsc.py on any data yet, I hope you could test this.

Cheers,

Felix
