### PR TITLE
Fix installation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ cd ldsc
 In order to install the Python dependencies, you will need the [Anaconda](https://store.continuum.io/cshop/anaconda/) Python distribution and package manager. After installing Anaconda, run the following commands to create an environment with LDSC's dependencies:
 
 ```
-conda env create --file environment.yml
+conda create -n ldsc python=2.7
+python -m ensurepip
+conda env update --file environment.yml --name ldsc --prune
 source activate ldsc
 ```
 


### PR DESCRIPTION
Hi, there is a problem (https://github.com/bulik/ldsc/issues/445) caused by the current installation code because python 2.7 is no longer supported by pip. 